### PR TITLE
Fix unions and write tests for them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/
 target/
+.bloop/
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Dependencies._
 
 globalSettings
 
-def commonSettings = Seq(version := "0.10")
+def commonSettings = Seq(version := "0.11")
 
 lazy val root = project
   .in(file("."))

--- a/rosetta/src/main/boilerplate/com.agilogy.rosetta.meta/Meta.template
+++ b/rosetta/src/main/boilerplate/com.agilogy.rosetta.meta/Meta.template
@@ -2,6 +2,7 @@ package com.agilogy.rosetta.meta
 
 import scala.collection.mutable
 import scala.collection.generic.CanBuildFrom
+import scala.reflect.ClassTag
 
 import com.github.ghik.silencer.silent
 
@@ -42,6 +43,7 @@ object Meta {
   implicit def option[A: Meta]: Option[A] = Option(Meta[A])
 
   final case class List[L[_], A](elementsMeta: Meta[A], asIterable: L[A] => Iterable[A], builder: () => mutable.Builder[A, L[A]]) extends Meta[L[A]]
+  // TODO: This ugly use of CanBuildForm must be removed!
   implicit def list[L[_],A: Meta](implicit cbf: CanBuildFrom[Nothing, A, L[A]], asIterable: L[A] => Iterable[A]): List[L, A] = List[L, A](Meta[A], asIterable, cbf.apply)
 
   sealed trait Record[A] extends Meta[A] {
@@ -93,12 +95,16 @@ object Meta {
     def options: scala.List[Record[_ <: A]]
   }
 
+    def cast[A](value: Any)(implicit classTag: ClassTag[A]): scala.Option[A] = value match {
+      case a: A => Some(a)
+      case _    => None
+    }
 
-  [2..10#final case class Union1[A, [#A0<:A#]](name: String)(
-    [#val cast0: A => scala.Option[A0]#]
-  )(
+  [2..10#final case class Union1[A, [#A0<:A:ClassTag#]](name: String)(
     implicit [#val option0: Meta.Record[A0]#]
   ) extends Union[A] {
+    [#val cast0: A => scala.Option[A0] = cast[A0](_)#
+    ]
     override def options: scala.List[Record[_ <: A]] = scala.List([#option0#])
   }#
 

--- a/rosettaCirce/src/main/boilerplate/com/agilogy/rosetta/circe/TemplatedCirceEncoders.template
+++ b/rosettaCirce/src/main/boilerplate/com/agilogy/rosetta/circe/TemplatedCirceEncoders.template
@@ -17,17 +17,18 @@ trait TemplatedCirceEncoders { self: CirceMetaProtocol.type =>
   // https://circe.github.io/circe/codecs/adt.html
   @silent("OptionPartial")
   def unionMetaEncoder[L[_], A](implicit meta: Meta.Union[A], unionCodecConfiguration: UnionCodecConfiguration[A]): Encoder[A] =
-    unionCodecConfiguration.discriminate(meta.name)(
+
       meta match {
         [2..10#case u @ Meta.Union1(_) =>
-          Encoder.instance { x =>
-            (
-              [#u.cast0(x).map(metaEncoder(u.option0).apply) #orElse
-              ]
-            ).get
-          }#
+
+            Encoder.instance { x =>
+              (
+                [#u.cast0(x).map(unionCodecConfiguration.discriminate(u.option0.name)(metaEncoder(u.option0)).apply) #orElse
+                ]
+              ).get
+            }#
         ]
       }
-    )
+
 
 }

--- a/rosettaCirce/src/main/scala/com/agilogy/rosetta/circe/CirceMetaProtocol.scala
+++ b/rosettaCirce/src/main/scala/com/agilogy/rosetta/circe/CirceMetaProtocol.scala
@@ -101,9 +101,10 @@ object CirceMetaProtocol extends TemplatedCirceEncoders with TemplatedCirceDecod
         discriminatorReader.flatMap { discriminator =>
           meta.options
             .find(_.name === discriminator)
-            .fold(Decoder.failed[A](DecodingFailure(s"Discriminator value $discriminator is invalid", List.empty)))(
-              recordMetaDecoder(_).widen[A]
-            )
+            .fold(Decoder.failed[A](DecodingFailure(s"Discriminator value $discriminator is invalid", List.empty))) {
+              d =>
+                Decoder.forProduct1[A, A](discriminator)(identity)(recordMetaDecoder(d).widen[A])
+            }
         }
       case None =>
         meta.options.map(metaDecoder(_).widen[A]).reduceLeft(_ or _)

--- a/rosettaCirce/src/test/scala/com/agilogy/rosetta/circe/CirceMetaReadSpec.scala
+++ b/rosettaCirce/src/test/scala/com/agilogy/rosetta/circe/CirceMetaReadSpec.scala
@@ -4,7 +4,7 @@ import cats.implicits._
 
 import com.agilogy.rosetta.circe.CirceEngine.decode
 import com.agilogy.rosetta.circe.CirceMetaProtocol._
-import com.agilogy.rosetta.circe.PersonMeta._
+import com.agilogy.rosetta.circe.ModelMeta._
 import com.agilogy.rosetta.read.{ ReadError, Segment }
 
 final class CirceMetaReadSpec extends munit.FunSuite {
@@ -44,6 +44,15 @@ final class CirceMetaReadSpec extends munit.FunSuite {
       Person("John", Option(Age(5)), List.empty, List.empty).asRight[ReadError]
     )
   }
+
+  test("read instances of a union meta") {
+    val value = """[{"car":{"brand":"Volkswagen","model":"Beatle"}},{"bicycle":{"color":"blue"}}]"""
+    assertEquals(
+      decode[List[Vehicle]](value),
+      List(Car("Volkswagen", "Beatle"), Bicycle("blue")).asRight[ReadError]
+    )
+  }
+
   val wrongPerson = """{"age":"young","favoriteColors":3, "brothersAges":[]}"""
   val wrongPersonErrors: ReadError =
     ReadError.MissingAttributeError.at("name") ++

--- a/rosettaCirce/src/test/scala/com/agilogy/rosetta/circe/CirceMetaWriteSpec.scala
+++ b/rosettaCirce/src/test/scala/com/agilogy/rosetta/circe/CirceMetaWriteSpec.scala
@@ -1,7 +1,7 @@
 package com.agilogy.rosetta.circe
 
 import CirceMetaProtocol._
-import PersonMeta._
+import ModelMeta._
 import io.circe.Encoder
 
 import com.agilogy.rosetta.meta.Meta
@@ -66,6 +66,14 @@ final class CirceMetaWriteSpec extends munit.FunSuite {
     assertEquals(
       write(Person("Mary", Option(Age(5)), brothersAges = List(Age(3), Age(7)))),
       """{"name":"Mary","age":5,"favoriteColors":[],"brothersAges":[3,7]}"""
+    )
+  }
+
+  test("write instances of an union") {
+    val vehicles: List[Vehicle] = List(Car("Vokswagen", "Beatle"), Bicycle("blue"))
+    assertEquals(
+      write(vehicles),
+      """[{"car":{"brand":"Vokswagen","model":"Beatle"}},{"bicycle":{"color":"blue"}}]"""
     )
   }
 

--- a/rosettaCirce/src/test/scala/com/agilogy/rosetta/circe/Model.scala
+++ b/rosettaCirce/src/test/scala/com/agilogy/rosetta/circe/Model.scala
@@ -9,3 +9,7 @@ final case class Person(
 )
 final case class Department(name: String, head: Person)
 final case class Foo(dept: Department)
+
+sealed trait Vehicle                               extends Product with Serializable
+final case class Car(brand: String, model: String) extends Vehicle
+final case class Bicycle(color: String)            extends Vehicle

--- a/rosettaCirce/src/test/scala/com/agilogy/rosetta/circe/ModelMeta.scala
+++ b/rosettaCirce/src/test/scala/com/agilogy/rosetta/circe/ModelMeta.scala
@@ -1,9 +1,11 @@
 package com.agilogy.rosetta.circe
 
+import scala.reflect.ClassTag
+
 import com.agilogy.rosetta.meta.Meta
 import com.agilogy.rosetta.meta.syntax._
 
-object PersonMeta {
+object ModelMeta {
 
   implicit val ageMeta: Meta[Age] = Meta.int.imap("age")(Age)(_.value)
 
@@ -20,5 +22,17 @@ object PersonMeta {
     Meta.record("department", "name".mandatory[String], "head".mandatory[Person])(Department)(Department.unapply)
 
   implicit val fooMeta: Meta[Foo] = Meta.record("foo", "dept".mandatory[Department])(Foo)(Foo.unapply)
+
+  def cast[A](value: Any)(implicit classTag: ClassTag[A]): Option[A] = value match {
+    case a: A => Some(a)
+    case _    => None
+  }
+
+  private implicit val carMeta: Meta.Record[Car] =
+    Meta.record("car", "brand".mandatory[String], "model".mandatory[String])(Car)(Car.unapply)
+  private implicit val bicycleMeta: Meta.Record[Bicycle] =
+    Meta.record("bicycle", "color".mandatory[String])(Bicycle)(Bicycle.unapply)
+
+  implicit val vehicleMeta: Meta[Vehicle] = Meta.Union2[Vehicle, Car, Bicycle]("vehicle")
 
 }


### PR DESCRIPTION
Meta of Union types and their circe codecs were unfinished. They were developed but not tested and (naturally) they didn't work out of the box.

This PR tests them and fixes the bugs found.

I didn't properly test all union discriminator options, as I'm in a hurry. The only strategy tested is the discriminator as an attribute that contains the actual object. See tests.